### PR TITLE
Fixed path resolution for windows

### DIFF
--- a/prince-api.js
+++ b/prince-api.js
@@ -220,7 +220,8 @@ Prince.prototype._execute = function (method, args) {
     var prog = this.config.binary;
     if (!fs.existsSync(prog)) {
         var findInPath = function (name) {
-            var p = process.env.PATH.split(":").map(function(item) {
+        	var pathSeparator = process.platform === 'win32' ? ";" : ":";
+            var p = process.env.PATH.split(pathSeparator).map(function(item) {
                 return path.join(item, name);
             });
             for (var i = 0, len = p.length; i < len; i++)


### PR DESCRIPTION
In Windows the PATH variable is separated by ";" instead of ":". This Pull request is OS independent and more importantly makes this code to work in Windows.

Note that process.platform returns 'win32' even if its Windows 64 bit, so it's working with every bit version. Seems to fix Issue #1 
