### PR TITLE
Make it able to track progress

### DIFF
--- a/prince-api.js
+++ b/prince-api.js
@@ -87,7 +87,9 @@ var princeOptions = {
     "disallow-copy":     false,
     "disallow-annotate": false,
     "disallow-modify":   false,
-    "scanfonts":         false
+    "scanfonts":         false,
+    "structured-log":    false,
+    "debug":             false
 };
 
 /*  API constructor  */


### PR DESCRIPTION
I've made some changes in order to facilitate progress tracking and better logging as the job progresses.

I've changed the .execute code to perform `spawn` instead of `execFile`, which allows us to handle stdout and stderr as they arrive. These can now be caputred line by line by chaning the Prince call with:

```
  .on('stderr', function(line) { ... })
  .on('stdout', function(line) { ... })
```
Registering multiple event handlers on the same events are possible too.

Price supports the option ``--structured-log=progress`` which can be used to track progress of the job.
This can now be achieved like this:

```
Prince()
  .inputs(...)
  .output(...)
  .option('structured-log', 'progress')
  .on('stderr', line => {
    trackProgress(line)
  })
  .execute()
```

The trackProgress function may look something like this:

````
function trackProgress(bundle, string) {
  if (string.substring(0, 4) === 'prg|') {
    const value = parseInt(string.split('|')[1], 0)
    console.log(`${value}% done`)
  }
}
````

Not sure if this is an ideal implementation though. First of, Prince doesn't seem to output anything to stdout, but I implemented a stdout handler as well, as I'm not sure if other versions of prince may output something to stdout.

Also, it is maybe a little strange with .on handlers when things like error is handled as a promise rejection (kind of a mix of two different patterns). In this regard the chaining function name could be called .onOutput instead. However I find the .on pattern to be familiar and flexible for possible future expansions.

What do you think?
