### PR TITLE
Add --output to args, which is required since v11, supported since v7

### DIFF
--- a/prince-api.js
+++ b/prince-api.js
@@ -279,6 +279,10 @@ Prince.prototype.execute = function () {
     this.config.inputs.forEach(function (input) {
         args.push(input);
     });
+
+    /* required from v11 on, supported since v7 */
+    /* would require a version check */
+    args.push("--output");
     args.push(this.config.output);
 
     /*  return promise for executing CLI  */


### PR DESCRIPTION
Actually we would have to determine the version of Prince used and act accordingly. Prince will not work when a version prior to 7 is used. However, it also fails now for 11.