### PR TITLE
Support output to stdout

### DIFF
--- a/prince-api.js
+++ b/prince-api.js
@@ -241,10 +241,14 @@ Prince.prototype._execute = function (method, args) {
             var options = {};
             options.timeout = self.config.timeout;
             options.cwd = self.config.cwd;
+            if (self.config.output === '-') {
+              options.encoding = 'buffer';
+              options.maxBuffer = Infinity;
+            }
             child_process.execFile(prog, args, options,
                 function (error, stdout, stderr) {
                     var m;
-                    if (error === null && (m = stderr.match(/prince:\s+error:\s+([^\n]+)/)))
+                    if (error === null && (m = stderr.toString().match(/prince:\s+error:\s+([^\n]+)/)))
                         reject({ error: m[1], stdout: stdout, stderr: stderr });
                     else if (error !== null)
                         reject({ error: error, stdout: stdout, stderr: stderr });


### PR DESCRIPTION
Prince allows you to to output directly to stdout if you pass a single hyphen as the output destination (i.e. `--output -`, see [Prince CLI docs](https://www.princexml.com/doc/command-line/)). At work we'd prefer to make use of that functionality and work with the resulting stdout buffer immediately, skipping the step of persisting it to disk.

We've made a few minor tweaks to get the above working successfully (thus, iff the user does `.output('-')`, then `.execute()` will resolve with stdout and stderr as buffers, and stdout will contain the PDF's contents). Is this something you'd be interested in merging?

**Notes:**
- `encoding` had to be set to `'buffer'`, as [execFile's](https://nodejs.org/api/child_process.html#child_process_child_process_execfile_file_args_options_callback) default would be to try and utf8-decode, leading to an un-openable PDF.
- `maxBuffer` had to be relaxed, as the default is 200kb, and any resulting PDF over that size would error out.
- `toString()` was added to cast stderr to a string (as it may now occasionally be a buffer).
- Branch isn't based off the head commit because we're using Prince 10.