### PR TITLE
Fixing TypeError on installation

### DIFF
--- a/prince-npm.js
+++ b/prince-npm.js
@@ -194,7 +194,7 @@ var extractTarball = function (tarball, destdir, stripdirs) {
     return new promise(function (resolve, reject) {
         fs.createReadStream(tarball)
             .pipe(zlib.createGunzip())
-            .pipe(tar.Extract({ path: destdir, strip: stripdirs }))
+            .pipe(tar.extract({ path: destdir, strip: stripdirs }))
             .on("error", function (error) { reject(error); })
             .on("end", function () { resolve(); });
     });


### PR DESCRIPTION
Calling `tar.Extract` on line 197 is throwing a TypeError. Although, `tar.extract` exists and changing this line will correctly extract PrinceXML distribution when installing.