### PR TITLE
fix binary not found on macOS

### DIFF
--- a/prince-api.js
+++ b/prince-api.js
@@ -111,7 +111,8 @@ function Prince (options) {
 
     /*  override defaults with more reasonable information about environment  */
     var install = [
-        { basedir: "prince/lib/prince",                     binary: "bin/prince"      },
+        { basedir: "lib/prince",                            binary: "bin/prince"      },
+        { basedir: "prince/lib/prince",                     binary: "bin/prince"      }, // maybe useless?
         { basedir: "prince\\program files\\Prince\\Engine", binary: "bin\\prince.exe" }
     ];
     var basedir;


### PR DESCRIPTION
Possibly fixing a Linux issue too?

The script would look for `/usr/local/lib/node_modules/<dependent>/node_modules/prince/prince/lib/prince/bin/prince` instead of `/usr/local/lib/node_modules/<dependent>/node_modules/prince/lib/prince/bin/prince`.

I did not change the Windows-related path.