### PR TITLE
Upgrade version of prince from 11.4 to 12.3

### DIFF
--- a/prince-npm.js
+++ b/prince-npm.js
@@ -77,11 +77,11 @@ var princeDownloadURL = function () {
     return new promise(function (resolve /*, reject */) {
         var id = process.arch + "-" + process.platform;
         if (id.match(/^ia32-win32$/))
-            resolve("https://www.princexml.com/download/prince-11.4-win32-setup.exe");
+            resolve("https://www.princexml.com/download/prince-12.3-win32-setup.exe");
         else if (id.match(/^x64-win32$/))
-            resolve("https://www.princexml.com/download/prince-11.4-win64-setup.exe");
+            resolve("https://www.princexml.com/download/prince-12.3-win64-setup.exe");
         else if (id.match(/^(?:ia32|x64)-darwin/))
-            resolve("https://www.princexml.com/download/prince-11.4-macosx.tar.gz");
+            resolve("https://www.princexml.com/download/prince-12.3-macosx.tar.gz");
         else {
             child_process.exec("sh \"" + __dirname + "/shtool\" platform -t binary", function (error, stdout /*, stderr */) {
                 if (error) {
@@ -91,40 +91,40 @@ var princeDownloadURL = function () {
                 var platform = stdout.toString().replace(/^(\S+).*\n?$/, "$1");
                 if (id.match(/^(?:ia32|x64)-linux/)) {
                     if (platform.match(/^ix86-ubuntu1[23](?:\.\d+)*$/))
-                        resolve("https://www.princexml.com/download/prince-11.4-ubuntu12.04-i386.tar.gz");
+                        resolve("https://www.princexml.com/download/prince-12.3-ubuntu12.04-i386.tar.gz");
                     else if (platform.match(/^amd64-ubuntu1[23](?:\.\d+)*$/))
-                        resolve("https://www.princexml.com/download/prince-11.4-ubuntu12.04-amd64.tar.gz");
+                        resolve("https://www.princexml.com/download/prince-12.3-ubuntu12.04-amd64.tar.gz");
                     else if (platform.match(/^ix86-ubuntu1[45](?:\.\d+)*$/))
-                        resolve("https://www.princexml.com/download/prince-11.4-ubuntu14.04-i386.tar.gz");
+                        resolve("https://www.princexml.com/download/prince-12.3-ubuntu14.04-i386.tar.gz");
                     else if (platform.match(/^amd64-ubuntu1[45](?:\.\d+)*$/))
-                        resolve("https://www.princexml.com/download/prince-11.4-ubuntu14.04-amd64.tar.gz");
+                        resolve("https://www.princexml.com/download/prince-12.3-ubuntu14.04-amd64.tar.gz");
                     else if (platform.match(/^ix86-ubuntu1[67](?:\.\d+)*$/))
-                        resolve("https://www.princexml.com/download/prince-11.4-ubuntu16.04-i386.tar.gz");
+                        resolve("https://www.princexml.com/download/prince-12.3-ubuntu16.04-i386.tar.gz");
                     else if (platform.match(/^amd64-ubuntu1[67](?:\.\d+)*$/))
-                        resolve("https://www.princexml.com/download/prince-11.4-ubuntu16.04-amd64.tar.gz");
+                        resolve("https://www.princexml.com/download/prince-12.3-ubuntu16.04-amd64.tar.gz");
                     else if (platform.match(/^ix86-ubuntu1[89](?:\.\d+)*$/))
-                        resolve("https://www.princexml.com/download/prince-11.4-ubuntu18.04-i386.tar.gz");
+                        resolve("https://www.princexml.com/download/prince-12.3-ubuntu18.04-i386.tar.gz");
                     else if (platform.match(/^amd64-ubuntu1[89](?:\.\d+)*$/))
-                        resolve("https://www.princexml.com/download/prince-11.4-ubuntu18.04-amd64.tar.gz");
+                        resolve("https://www.princexml.com/download/prince-12.3-ubuntu18.04-amd64.tar.gz");
                     else if (platform.match(/^amd64-debian9(?:\.\d+)*$/))
-                        resolve("https://www.princexml.com/download/prince-11.4-debian9.1-amd64.tar.gz");
+                        resolve("https://www.princexml.com/download/prince-12.3-debian9.1-amd64.tar.gz");
                     else if (platform.match(/^amd64-debian8(?:\.\d+)*$/))
-                        resolve("https://www.princexml.com/download/prince-11.4-debian8.10-amd64.tar.gz");
+                        resolve("https://www.princexml.com/download/prince-12.3-debian8.10-amd64.tar.gz");
                     else if (platform.match(/^amd64-debian7(?:\.\d+)*$/))
-                        resolve("https://www.princexml.com/download/prince-11.4-debian7.4-amd64.tar.gz");
+                        resolve("https://www.princexml.com/download/prince-12.3-debian7.4-amd64.tar.gz");
                     else if (platform.match(/^amd64-centos7(?:\.\d+)*$/))
-                        resolve("https://www.princexml.com/download/prince-11.4-centos7-x86_64.tar.gz");
+                        resolve("https://www.princexml.com/download/prince-12.3-centos7-x86_64.tar.gz");
                     else if (platform.match(/^amd64-centos6(?:\.\d+)*$/))
-                        resolve("https://www.princexml.com/download/prince-11.4-centos6-x86_64.tar.gz");
+                        resolve("https://www.princexml.com/download/prince-12.3-centos6-x86_64.tar.gz");
                     else if (platform.match(/^ix86-centos6(?:\.\d+)*$/))
-                        resolve("https://www.princexml.com/download/prince-11.4-centos6-i386.tar.gz");
+                        resolve("https://www.princexml.com/download/prince-12.3-centos6-i386.tar.gz");
                     else if (id.match(/^ia32-/))
-                        resolve("https://www.princexml.com/download/prince-11.4-linux-generic-i686.tar.gz");
+                        resolve("https://www.princexml.com/download/prince-12.3-linux-generic-i686.tar.gz");
                     else if (id.match(/^x64-/))
-                        resolve("https://www.princexml.com/download/prince-11.4-linux-generic-x86_64.tar.gz");
+                        resolve("https://www.princexml.com/download/prince-12.3-linux-generic-x86_64.tar.gz");
                 }
                 else if (id.match(/^x64-freebsd/))
-                    resolve("https://www.princexml.com/download/prince-11.4-freebsd11.1-amd64.tar.gz");
+                    resolve("https://www.princexml.com/download/prince-12.3-freebsd11.1-amd64.tar.gz");
                 else {
                     console.log(chalk.red("ERROR: PrinceXML not available for platform \"" + platform + "\""));
                     process.exit(1);


### PR DESCRIPTION
I would like to update prince to above 12.2.1 because of this fix:

```
Prince 12.2.1
September 2018

Fixed bug affecting fonts on MacOS 10.14 (Mojave).
```
See: https://www.princexml.com/releases/12/

I did not seen any problems / conflicts while testing it.