### PR TITLE
Fixed bug where local installation of prince will not work on macOS because of incorrect permissions

### DIFF
--- a/prince-npm.js
+++ b/prince-npm.js
@@ -277,8 +277,17 @@ if (process.argv[2] === "install") {
                     fs.writeFileSync(destfile, data, { encoding: null });
                     mkdirp.sync(destdir);
                     extractZipfile(destfile, "prince-14.2-macos", destdir).then(function () {
-                        fs.unlinkSync(destfile);
+                        console.log("++ making local prince binary executable");
+                        const binaryfile = path.join(destdir, "lib/prince/bin/prince");
+                        const chmod755 = fs.constants.S_IRWXU | fs.constants.S_IRGRP | fs.constants.S_IXGRP | fs.constants.S_IROTH | fs.constants.S_IXOTH;
+                        fs.chmodSync(binaryfile, chmod755);
+                        const newmode = fs.statSync(binaryfile).mode;
+                        if ((newmode & chmod755) === chmod755) {
                         console.log("-- OK: local PrinceXML installation now available");
+                        } else {
+                            console.log(chalk.red("** ERROR: failed to make local prince binary executable"));
+                        }
+                        fs.unlinkSync(destfile);
                     }, function (error) {
                         console.log(chalk.red("** ERROR: failed to extract: " + error));
                     });


### PR DESCRIPTION
If a global copy of prince is not installed, node-prince will attempt to install a local copy. However this local copy will not work. It results in an `EACCES` error when attempting to spawn prince.

```
Error occurred in handler for 'generatePDF': {
  error: Error: spawn /Users/junjie/Documents/Git Repositories/sampleProject/node_modules/prince/prince/lib/prince/bin/prince EACCES
      at Process.ChildProcess._handle.onexit (node:internal/child_process:282:19)
      at onErrorNT (node:internal/child_process:480:16)
      at processTicksAndRejections (node:internal/process/task_queues:83:21) {
    errno: -13,
    code: 'EACCES',
    syscall: 'spawn /Users/junjie/Documents/Git Repositories/sampleProject/node_modules/prince/prince/lib/prince/bin/prince',
    path: '/Users/junjie/Documents/Git Repositories/sampleProject/node_modules/prince/prince/lib/prince/bin/prince',
    spawnargs: [
      '--prefix',
      '/Users/junjie/Documents/Git Repositories/sampleProject/node_modules/prince/prince/lib/prince',
      '/var/folders/1y/sf0qcwvd5csbzn8bkn1bndjc0000gn/T/output.html',
      '--output',
      '/var/folders/1y/sf0qcwvd5csbzn8bkn1bndjc0000gn/T/output-temp.pdf'
    ],
    cmd: '/Users/junjie/Documents/Git Repositories/sampleProject/node_modules/prince/prince/lib/prince/bin/prince --prefix /Users/junjie/Documents/Git Repositories/sampleProject/node_modules/prince/prince/lib/prince /var/folders/1y/sf0qcwvd5csbzn8bkn1bndjc0000gn/T/output.html --output /var/folders/1y/sf0qcwvd5csbzn8bkn1bndjc0000gn/T/output-temp.pdf'
  },
  stdout: <Buffer >,
  stderr: <Buffer >
}
```

This is because the local installation does not have the appropriate permissions set, namely the +x executable flag. If you examine the install.sh script included with prince-14.2-macos.zip, you'll see this portion where the binary is copied to the destination and with the file permissions 755.

```
install_bin () {
    install -m 755 "$1" "$2"
}
```

I believe this would also affect the *nix builds, but I've not tested them. I'll be sending in a PR shortly to fix the Mac version.

Fixes: #39 