### PR TITLE
Download and install the x86 version of Prince for macOS on ARM-based Macs

### DIFF
--- a/prince-npm.js
+++ b/prince-npm.js
@@ -83,6 +83,8 @@ var princeDownloadURL = function () {
             resolve("https://www.princexml.com/download/prince-14.2-win64-setup.exe");
         else if (id.match(/^(?:ia32|x64)-darwin/))
             resolve("https://www.princexml.com/download/prince-14.2-macos.zip");
+        else if (id.match(/^arm64-darwin/)) /* Prince does not have an ARM build yet, but the Intel version will work as long as Rosetta 2 is installed. Leave this condition here and replace with the ARM build when available. */
+            resolve("https://www.princexml.com/download/prince-14.2-macos.zip");
         else {
             child_process.exec("sh \"" + __dirname + "/shtool\" platform -t binary", function (error, stdout /*, stderr */) {
                 if (error) {


### PR DESCRIPTION
The x86 version works under Rosetta, and should be downloaded. I've separated it into another line instead of modifying this line

```
        else if (id.match(/^(?:ia32|x64)-darwin/))
```

to

```
        else if (id.match(/^(?:ia32|x64|arm64)-darwin/))
```

so that when the Prince team releases an ARM version we can provide separate URL.

This fixes https://github.com/rse/node-prince/issues/36