### PR TITLE
Replace request module with axios

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name":        "prince",
     "homepage":    "http://github.com/rse/node-prince",
     "description": "Node API for executing XML/HTML to PDF renderer PrinceXML via prince(1) CLI",
-    "version":     "1.9.14",
+    "version":     "1.9.15",
     "license":     "MIT",
     "author": {
         "name":    "Dr. Ralf S. Engelschall",
@@ -27,10 +27,10 @@
         "grunt-eslint":         "24.3.0"
     },
     "dependencies" : {
+        "axios":                "1.5.1",
         "promise":              "8.3.0",
         "lodash":               "4.17.21",
         "progress":             "2.0.3",
-        "request":              "2.88.2",
         "which":                "4.0.0",
         "chalk":                "4.1.2",
         "tar":                  "6.1.15",

--- a/prince-npm.js
+++ b/prince-npm.js
@@ -173,10 +173,6 @@ var downloadData = function (url) {
                             total:      progressEvent.total
                         });
                 }
-                const percentage = Math.round(
-                    (progressEvent.loaded * 100) / progressEvent.total
-                );
-
                 progress_bar.tick(progressEvent.loaded);
             }
         };

--- a/prince-npm.js
+++ b/prince-npm.js
@@ -286,13 +286,11 @@ if (process.argv[2] === "install") {
                     mkdirp.sync(destdir);
 
                     extractZipfile(destfile, "prince-15-macos", destdir).then(function () {
-                        console.log('Extracted');
                         fs.chmodSync(path.join(destdir, "lib/prince/bin/prince"), fs.constants.S_IRWXU
                             | fs.constants.S_IRGRP | fs.constants.S_IXGRP | fs.constants.S_IROTH | fs.constants.S_IXOTH);
                         fs.unlinkSync(destfile);
                         console.log("-- OK: local PrinceXML installation now available");
                     }, function (error) {
-                        console.log('MNOT Extracted');
                         console.log(chalk.red("** ERROR: failed to extract: " + error));
                     });
                 }

--- a/prince-npm.js
+++ b/prince-npm.js
@@ -209,22 +209,6 @@ var downloadData = function (url) {
             }).catch(function(error) {
                 reject("download failed: " + error);
             });
-
-            // var progress_bar = null;
-            // req.on("response", function (response) {
-            //     var len = parseInt(response.headers["content-length"], 10);
-            //     progress_bar = new progress(
-            //         "-- download: [:bar] :percent (ETA: :etas)", {
-            //         complete:   "#",
-            //         incomplete: "=",
-            //         width:      40,
-            //         total:      len
-            //     });
-            // });
-            // req.on("data", function (data) {
-            //     if (progress_bar !== null)
-            //         progress_bar.tick(data.length);
-            // });
         });
     });
 };


### PR DESCRIPTION
This PR removes the dependency on `request` which has been deprecated and contains vulnerabilities: [GHSA-p8p7-x288-28g6](https://github.com/advisories/GHSA-p8p7-x288-28g6)

Using axios instead to download the prince binary.

npm audit returns 0 vulnerabilities