### PR TITLE
Update for Prince 16

### DIFF
--- a/prince-api.js
+++ b/prince-api.js
@@ -150,8 +150,8 @@ function Prince (options) {
 
     /*  override defaults with more reasonable information about environment  */
     var install = [
-        { basedir: "prince/lib/prince",                     binary: "bin/prince"      },
-        { basedir: "prince\\program files\\Prince\\Engine", binary: "bin\\prince.exe" }
+        { basedir: "prince/lib/prince", binary: "bin/prince"      },
+        { basedir: "prince",            binary: "bin\\prince.exe" }
     ];
     var basedir;
     var binary;

--- a/prince-npm.js
+++ b/prince-npm.js
@@ -78,7 +78,7 @@ var princeDownloadURL = function () {
         var id = process.arch + "-" + process.platform;
         if (id.match(/^ia32-win32$/))
             resolve("https://www.princexml.com/download/prince-15.4-win32-setup.exe");
-        else if (id.match(/^x64-win32$/))
+        else if (id.match(/^(?:x64|arm64)-win32$/))
             resolve("https://www.princexml.com/download/prince-15.4-win64-setup.exe");
         else if (id.match(/^(?:x64|arm64)-darwin/))
             resolve("https://www.princexml.com/download/prince-16-macos.zip");

--- a/prince-npm.js
+++ b/prince-npm.js
@@ -77,9 +77,9 @@ var princeDownloadURL = function () {
     return new promise(function (resolve /*, reject */) {
         var id = process.arch + "-" + process.platform;
         if (id.match(/^ia32-win32$/))
-            resolve("https://www.princexml.com/download/prince-15.4-win32-setup.exe");
-        else if (id.match(/^(?:x64|arm64)-win32$/))
-            resolve("https://www.princexml.com/download/prince-15.4-win64-setup.exe");
+            resolve("https://www.princexml.com/download/prince-16-win32.zip");
+        else if (id.match(/^(:?x64|arm64)-win32$/))
+            resolve("https://www.princexml.com/download/prince-16-win64.zip");
         else if (id.match(/^(?:x64|arm64)-darwin/))
             resolve("https://www.princexml.com/download/prince-16-macos.zip");
         else {
@@ -249,23 +249,15 @@ if (process.argv[2] === "install") {
                 destdir = path.join(__dirname, "prince");
                 var destfile;
                 if (process.platform === "win32") {
-                    destfile = path.join(__dirname, "prince.exe");
+                    destfile = path.join(__dirname, "prince.zip");
                     fs.writeFileSync(destfile, data, { encoding: null });
-                    var args = [ "/s", "/a", "/vTARGETDIR=\"" + path.resolve(destdir) + "\" /qn" ];
-                    child_process.execFile(destfile, args, function (error, stdout, stderr) {
-                        if (error !== null) {
-                            console.log(chalk.red("** ERROR: failed to extract: " + error));
-                            stdout = stdout.toString();
-                            stderr = stderr.toString();
-                            if (stdout !== "")
-                                console.log("** STDOUT: " + stdout);
-                            if (stderr !== "")
-                                console.log("** STDERR: " + stderr);
-                        }
-                        else {
-                            fs.unlinkSync(destfile);
-                            console.log("-- OK: local PrinceXML installation now available");
-                        }
+                    mkdirp.sync(destdir);
+                    var stripDir = process.arch == "ia32" ? "prince-16-win32" : "prince-16-win64";
+                    extractZipfile(destfile, stripDir, destdir).then(function () {
+                        fs.unlinkSync(destfile);
+                        console.log("-- OK: local PrinceXML installation now available");
+                    }, function (error) {
+                        console.log(chalk.red("** ERROR: failed to extract: " + error));
                     });
                 }
                 else if (process.platform === "darwin") {

--- a/prince-npm.js
+++ b/prince-npm.js
@@ -81,7 +81,7 @@ var princeDownloadURL = function () {
         else if (id.match(/^x64-win32$/))
             resolve("https://www.princexml.com/download/prince-15.4-win64-setup.exe");
         else if (id.match(/^(?:x64|arm64)-darwin/))
-            resolve("https://www.princexml.com/download/prince-15.4-macos.zip");
+            resolve("https://www.princexml.com/download/prince-16-macos.zip");
         else {
             child_process.exec("sh \"" + __dirname + "/shtool\" platform -t binary", function (error, stdout /*, stderr */) {
                 if (error) {
@@ -90,57 +90,51 @@ var princeDownloadURL = function () {
                 }
                 var platform = stdout.toString().replace(/^(\S+).*\n?$/, "$1");
                 if (id.match(/^x64-linux/)) {
-                    if (platform.match(/^amd64-ubuntu1[89](?:\.\d+)*$/))
-                        resolve("https://www.princexml.com/download/prince-15.4-ubuntu18.04-amd64.tar.gz");
-                    else if (platform.match(/^amd64-ubuntu2[01](?:\.\d+)*$/))
-                        resolve("https://www.princexml.com/download/prince-15.4-ubuntu20.04-amd64.tar.gz");
+                    if (platform.match(/^amd64-ubuntu2[01](?:\.\d+)*$/))
+                        resolve("https://www.princexml.com/download/prince-16-ubuntu20.04-amd64.tar.gz");
                     else if (platform.match(/^amd64-ubuntu2[23](?:\.\d+)*$/))
-                        resolve("https://www.princexml.com/download/prince-15.4-ubuntu22.04-amd64.tar.gz");
+                        resolve("https://www.princexml.com/download/prince-16-ubuntu22.04-amd64.tar.gz");
                     else if (platform.match(/^amd64-ubuntu24(?:\.\d+)*$/))
-                        resolve("https://www.princexml.com/download/prince-15.4-ubuntu24.04-amd64.tar.gz");
+                        resolve("https://www.princexml.com/download/prince-16-ubuntu24.04-amd64.tar.gz");
                     else if (platform.match(/^amd64-debian12(?:\.\d+)*$/))
-                        resolve("https://www.princexml.com/download/prince-15.4-debian12-amd64.tar.gz");
+                        resolve("https://www.princexml.com/download/prince-16-debian12-amd64.tar.gz");
                     else if (platform.match(/^amd64-debian11(?:\.\d+)*$/))
-                        resolve("https://www.princexml.com/download/prince-15.4-debian11-amd64.tar.gz");
-                    else if (platform.match(/^amd64-debian10(?:\.\d+)*$/))
-                        resolve("https://www.princexml.com/download/prince-15.4-debian10-amd64.tar.gz");
-                    else if (platform.match(/^amd64-centos7(?:\.\d+)*$/))
-                        resolve("https://www.princexml.com/download/prince-15.4-centos7-x86_64.tar.gz");
+                        resolve("https://www.princexml.com/download/prince-16-debian11-amd64.tar.gz");
                     else if (platform.match(/^amd64-almalinux9(?:\.\d+)*$/))
-                        resolve("https://www.princexml.com/download/prince-15.4-almalinux9-x86_64.tar.gz");
+                        resolve("https://www.princexml.com/download/prince-16-almalinux9-x86_64.tar.gz");
                     else if (platform.match(/^amd64-almalinux8(?:\.\d+)*$/))
-                        resolve("https://www.princexml.com/download/prince-15.4-almalinux8-x86_64.tar.gz");
+                        resolve("https://www.princexml.com/download/prince-16-almalinux8-x86_64.tar.gz");
+                    else if (platform.match(/^amd64-alpine3\.21(?:\.\d+)*$/))
+                        resolve("https://www.princexml.com/download/prince-16-alpine3.21-x86_64.tar.gz");
                     else if (platform.match(/^amd64-alpine3\.20(?:\.\d+)*$/))
-                        resolve("https://www.princexml.com/download/prince-15.4-alpine3.20-x86_64.tar.gz");
+                        resolve("https://www.princexml.com/download/prince-16-alpine3.20-x86_64.tar.gz");
                     else if (platform.match(/^amd64-alpine3\.19(?:\.\d+)*$/))
-                        resolve("https://www.princexml.com/download/prince-15.4-alpine3.19-x86_64.tar.gz");
+                        resolve("https://www.princexml.com/download/prince-16-alpine3.19-x86_64.tar.gz");
                     else if (platform.match(/^amd64-alpine3\.18(?:\.\d+)*$/))
-                        resolve("https://www.princexml.com/download/prince-15.4-alpine3.18-x86_64.tar.gz");
-                    else if (platform.match(/^amd64-alpine3\.17(?:\.\d+)*$/))
-                        resolve("https://www.princexml.com/download/prince-15.4-alpine3.17-x86_64.tar.gz");
-                    else if (platform.match(/^amd64-opensuse15.4(?:\.\d+)*$/))
-                        resolve("https://www.princexml.com/download/prince-15.4-opensuse15.4-x86_64.tar.gz");
+                        resolve("https://www.princexml.com/download/prince-16-alpine3.18-x86_64.tar.gz");
+                    else if (platform.match(/^amd64-opensuse15\.6(?:\.\d+)*$/))
+                        resolve("https://www.princexml.com/download/prince-16-opensuse15.6-x86_64.tar.gz");
                     else if (id.match(/^x64-/))
-                        resolve("https://www.princexml.com/download/prince-15.4-linux-generic-x86_64.tar.gz");
+                        resolve("https://www.princexml.com/download/prince-16-linux-generic-x86_64.tar.gz");
                 }
                 else if (id.match(/^arm64-linux/)) {
                     if (platform.match(/^arm64-ubuntu24(?:\.\d+)*$/))
-                        resolve("https://www.princexml.com/download/prince-15.4-ubuntu24.04-arm64.tar.gz");
+                        resolve("https://www.princexml.com/download/prince-16-ubuntu24.04-arm64.tar.gz");
                     else if (platform.match(/^arm64-ubuntu2[23](?:\.\d+)*$/))
-                        resolve("https://www.princexml.com/download/prince-15.4-ubuntu22.04-arm64.tar.gz");
+                        resolve("https://www.princexml.com/download/prince-16-ubuntu22.04-arm64.tar.gz");
                     else if (platform.match(/^arm64-debian12(?:\.\d+)*$/))
-                        resolve("https://www.princexml.com/download/prince-15.4-debian12-arm64.tar.gz");
+                        resolve("https://www.princexml.com/download/prince-16-debian12-arm64.tar.gz");
                     else if (platform.match(/^arm64-debian11(?:\.\d+)*$/))
-                        resolve("https://www.princexml.com/download/prince-15.4-debian11-arm64.tar.gz");
+                        resolve("https://www.princexml.com/download/prince-16-debian11-arm64.tar.gz");
                     else if (platform.match(/^aarch64-alpine[23](?:\.\d+)*$/))
-                        resolve("https://www.princexml.com/download/prince-15.4-linux-generic-aarch64-musl.tar.gz");
+                        resolve("https://www.princexml.com/download/prince-16-linux-generic-aarch64-musl.tar.gz");
                     else
-                        resolve("https://www.princexml.com/download/prince-15.4-linux-generic-aarch64.tar.gz");
+                        resolve("https://www.princexml.com/download/prince-16-linux-generic-aarch64.tar.gz");
                 }
                 else if (platform.match(/^amd64-freebsd13(?:\.\d+)*/))
-                    resolve("https://www.princexml.com/download/prince-15.4-freebsd13.0-amd64.tar.gz");
+                    resolve("https://www.princexml.com/download/prince-16-freebsd13.0-amd64.tar.gz");
                 else if (platform.match(/^amd64-freebsd14(?:\.\d+)*/))
-                    resolve("https://www.princexml.com/download/prince-15.4-freebsd14.0-amd64.tar.gz");
+                    resolve("https://www.princexml.com/download/prince-16-freebsd14.0-amd64.tar.gz");
                 else {
                     console.log(chalk.red("ERROR: PrinceXML not available for platform \"" + platform + "\" (\"" + id + "\")"));
                     process.exit(1);
@@ -278,7 +272,7 @@ if (process.argv[2] === "install") {
                     destfile = path.join(__dirname, "prince.zip");
                     fs.writeFileSync(destfile, data, { encoding: null });
                     mkdirp.sync(destdir);
-                    extractZipfile(destfile, "prince-15.4-macos", destdir).then(function () {
+                    extractZipfile(destfile, "prince-16-macos", destdir).then(function () {
                         fs.chmodSync(path.join(destdir, "lib/prince/bin/prince"), fs.constants.S_IRWXU
                             | fs.constants.S_IRGRP | fs.constants.S_IXGRP | fs.constants.S_IROTH | fs.constants.S_IXOTH);
                         fs.unlinkSync(destfile);
@@ -320,4 +314,3 @@ else {
     console.log(chalk.red("ERROR: invalid argument"));
     process.exit(1);
 }
-


### PR DESCRIPTION
This pull request updates the downloads for Prince 16. We no longer publish `.exe` installers for Windows (only msi installer packages), so I switched Windows to use the Windows ZIP files.

I also made the install script recognise Windows on ARM (required so I could test on my laptop). We don't publish a Windows on ARM version of Prince yet, but the x64 runs fine under the built-in emulation in Windows, so this is what is used in this case.

Finally, we don't have Prince 16 packages for some EoL Linux distros, so I dropped these, and added Alpine 3.21.